### PR TITLE
allow ice retry

### DIFF
--- a/_init.sh
+++ b/_init.sh
@@ -72,8 +72,7 @@ installwithpython34() {
 }
 
 installwithpython277() {
-    pushd . 
-    cd $EXT_DIR
+    pushd $EXT_DIR >/dev/null
     echo "Installing Python 2.7.7"
     curl -kL http://xrl.us/pythonbrewinstall | bash
     source $HOME/.pythonbrew/etc/bashrc
@@ -92,7 +91,7 @@ installwithpython277() {
     python get-pip.py --user &> /dev/null
     debugme pwd 
     debugme ls 
-    popd 
+    popd >/dev/null
     pip remove requests
     pip install --user -U requests 
     pip install --user -U pip
@@ -170,8 +169,7 @@ fi
 # Install Cloud Foundry CLI #
 #############################
 echo "Installing Cloud Foundry CLI"
-pushd . 
-cd $EXT_DIR 
+pushd $EXT_DIR >/dev/null
 gunzip cf-linux-amd64.tgz &> /dev/null
 tar -xvf cf-linux-amd64.tar  &> /dev/null
 cf help &> /dev/null
@@ -181,7 +179,7 @@ if [ $RESULT -ne 0 ]; then
     ${EXT_DIR}/print_help.sh
     exit $RESULT
 fi  
-popd
+popd >/dev/null
 echo -e "${label_color}Successfully installed Cloud Foundry CLI ${no_color}"
 
 #################################
@@ -216,6 +214,10 @@ else
 
 fi  
 
+########################
+# Setup git_retry      #
+########################
+source ${EXT_DIR}/git_util.sh
 
 ################################
 # Login to Container Service   #
@@ -268,7 +270,7 @@ else
     debugme cat /home/jenkins/.cf/config.json | cut -c1-2
     debugme cat /home/jenkins/.cf/config.json | cut -c3-
     debugme echo "testing ice login via ice info command"
-    ice --verbose info > info.log 2> /dev/null
+    with_retry ice --verbose info > info.log 2> /dev/null
     RESULT=$?
     debugme cat info.log 
     if [ $RESULT -eq 0 ]; then
@@ -333,16 +335,10 @@ else
 fi 
 
 
-########################
-# Setup git_retry      #
-########################
-source ${EXT_DIR}/git_util.sh
-
 ################################
 # get the extensions utilities #
 ################################
-pushd . >/dev/null
-cd $EXT_DIR 
+pushd $EXT_DIR >/dev/null
 git_retry clone https://github.com/Osthanes/utilities.git utilities
 popd >/dev/null
 

--- a/git_util.sh
+++ b/git_util.sh
@@ -19,30 +19,55 @@
 #set -x
 
 # this script is not in Osthanes/utilities because then git would be needed to access it
+# and it contains the git retry code.  not renamed for compatibility with existing pipelines
+
+# use this function to add retries to a command that returns non-zero on fail
+with_retry() {
+    if [[ $DEBUG -eq 1 ]]; then
+        local START_TIME=$(date +"%s")
+    fi
+    local RETRY_CALL="$*"
+    echo $RETRY_CALL
+    $RETRY_CALL
+    local RETRY_RC=$?
+    local CURRENT_RETRY_COUNT=0
+    if [ -z "$CMD_RETRY" ]; then
+        local CMD_RETRY=5
+    fi
+    while [[  $CURRENT_RETRY_COUNT -lt $CMD_RETRY && $RETRY_RC -ne 0 ]]; do
+        ((CURRENT_RETRY_COUNT++))
+        echo -e "${label_color}${1} command failed; retrying in 3 seconds${no_color} ($CURRENT_RETRY_COUNT of $CMD_RETRY)"
+        sleep 3
+        echo $RETRY_CALL
+        $RETRY_CALL
+        RETRY_RC=$?
+    done
+
+    if [ $RETRY_RC -ne 0 ]; then
+        echo -e "${red}${1} command failed: $RETRY_CALL${no_color}" | tee -a "$ERROR_LOG_FILE"
+    fi
+
+    if [[ $DEBUG -eq 1 ]]; then
+        local END_TIME=$(date +"%s")
+        export LAST_CMD_TIME=$(($END_TIME-$START_TIME))
+        echo -e "Cmd '$RETRY_CALL' runtime of `date -u -d @\"$LAST_CMD_TIME\" +'%-Mm %-Ss'`"
+    fi
+
+    return $RETRY_RC
+}
 
 # use this function to help avoid pipeline problems when accessing git repositories
 git_retry() {
-    local GIT_CALL="git $*"
-    echo $GIT_CALL
-    $GIT_CALL
-    local GIT_RC=$?
-    local GIT_RETRY_COUNT=0
-    if [ -z "$GIT_RETRY" ]; then
-        local GIT_RETRY=5
+    if [ -n "$GIT_RETRY" ]; then
+        local SAVE_CMD_RETRY=$CMD_RETRY
+        export CMD_RETRY=$GIT_RETRY
     fi
-    while [[  $GIT_RETRY_COUNT -lt $GIT_RETRY && $GIT_RC -ne 0 ]]; do
-        ((GIT_RETRY_COUNT++))
-        echo -e "${label_color}git command failed; retrying in 30 seconds${no_color} ($GIT_RETRY_COUNT of $GIT_RETRY)"
-        sleep 3
-        echo $GIT_CALL
-        $GIT_CALL
-        GIT_RC=$?
-    done
-
-    if [ $GIT_RC -ne 0 ]; then
-        echo -e "${red}git command failed: $GIT_CALL${no_color}" | tee -a "$ERROR_LOG_FILE"
+    with_retry "git" $*
+    if [ -n "$SAVE_CMD_RETRY" ]; then
+        export CMD_RETRY=$SAVE_CMD_RETRY
     fi
 }
 
-#export function
+#export functions
 export -f git_retry
+export -f with_retry


### PR DESCRIPTION
modify the git_retry to allow it to be used as a general retry block, use for ice info call during login test check.  also adjust the pushd calls to not pollute the logs with random long dir names
