### PR TITLE
Updating the memory sizes to match what is available

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -74,8 +74,9 @@ git_retry clone https://github.com/Osthanes/deployscripts.git deployscripts
 #      NAME              Value         Description
 #   =============      =========     ==============
 #   BIND_TO             String       Specify a Bluemix application name that whose bound services you wish to make available to the container.  By default this is not set.
-#   CONTAINER_SIZE      String       Specify container size: m1.tiny (256), m1.small (512), m1.medium (1024), m1.large (2048).
-#                                    Default is m1.tiny (256).
+#   CONTAINER_SIZE      String       Specify container size: pico (64), nano (128), micro (256), tiny (512), small (1024), medium (2048),
+#                                                            large (4096), x-large (8192), 2x-large (16384).
+#                                    Default is micro (256).
 #   CONCURRENT_VERSIONS Number       Number of versions of this container to leave active.  
 #                                    Default is 1
 #
@@ -92,8 +93,9 @@ git_retry clone https://github.com/Osthanes/deployscripts.git deployscripts
 #   AUTO_RECOVERY:      Boolean      Set auto-recovery to true/false.  Default value is false.
 
 #                                    Default is false.
-#   CONTAINER_SIZE      String       Specify container size: m1.tiny (256), m1.small (512), m1.medium (1024), m1.large (2048).
-#                                    Default is m1.tiny (256).
+#   CONTAINER_SIZE      String       Specify container size: pico (64), nano (128), micro (256), tiny (512), small (1024), medium (2048),
+#                                                            large (4096), x-large (8192), 2x-large (16384).
+#                                    Default is micro (256).
 #   CONCURRENT_VERSIONS Number       Number of versions of this group to leave active.
 #                                    Default is 1
 # IF YOU WANT CONTAINER GROUPS .. uncomment the next line, and comment out the previous deployment line (/bin/bash deployscripts/deploygroup.sh)


### PR DESCRIPTION
This should not be merged/deployed until deployscripts is updated to support the new values documented.

Previous values (i.e.: m1.tiny) will still be supported at their previous sizes (i.e.:256) to not break earlier deployers.
